### PR TITLE
disk image ci job

### DIFF
--- a/.github/workflows/autosd-bootc-disk-images.yml
+++ b/.github/workflows/autosd-bootc-disk-images.yml
@@ -1,0 +1,133 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+name: "AutoSD: Bootc Disk Images"
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/autosd-bootc-disk-images.yml
+  workflow_dispatch:
+
+jobs:
+  build-disk-image:
+    strategy:
+      matrix:
+        platform: [x86_64, aarch64]
+        include:
+          - platform: x86_64
+            runner: ubuntu-24.04
+            oci_arch: amd64
+            aib_targets: qemu
+          - platform: aarch64
+            runner: ubuntu-24.04-arm
+            oci_arch: arm64
+            aib_targets: qemu,rpi4
+
+    runs-on: ${{ matrix.runner }}
+    env:
+      AIB_BUILD_CONTAINER_IMAGE: ghcr.io/eclipse-autosd/eclipse-autosd-builder:latest
+      AIB_LOCAL_CONTAINER_STORAGE: ${{ github.workspace }}/_build/containers-storage
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Base Dependencies
+        run: |
+          sudo apt update -y
+          sudo apt install -y podman tree
+      - name: Podman Info
+        run: podman info
+      - name: Install AIB container script
+        run: |
+          wget -O auto-image-builder.sh \
+          https://gitlab.com/CentOS/automotive/src/automotive-image-builder/-/raw/main/auto-image-builder.sh?ref_type=heads
+          chmod +x auto-image-builder.sh
+      - name: Prepare Build
+        run: |
+          mkdir -p $PWD/_build/{containers-storage,outputs}
+      - name: Fetch Builder Image
+        run: |
+          podman run -it --rm \
+          -v $PWD/_build/containers-storage:/var/lib/containers/storage \
+          quay.io/containers/skopeo:latest \
+          copy docker://${AIB_BUILD_CONTAINER_IMAGE} containers-storage:${AIB_BUILD_CONTAINER_IMAGE}
+      - name: Generate Disk Images
+        run: |
+          IFS=',' read -ra AIB_TARGETS <<< "${{matrix.aib_targets}}"
+          for aib_target in "${AIB_TARGETS[@]}"; do
+
+            if [ "${aib_target}" == 'qemu' ]; then
+              aib_ext=qcow2
+            else
+              aib_ext=img
+            fi
+
+            aib_oci_image=ghcr.io/eclipse-autosd/eclipse-autosd-bootc-${aib_target}:latest
+            aib_oci_archive=eclipse-autosd-bootc-${aib_target}-latest.oci
+            aib_disk_image=eclipse-autosd-bootc-${aib_target}-${{ matrix.platform }}.${aib_ext}
+
+            echo from ${aib_oci_image} to ${aib_disk_image}
+    
+            podman run -it --rm \
+            -v $PWD/_build/containers-storage:/var/lib/containers/storage \
+            -v $PWD/_build/outputs:/outputs \
+            quay.io/containers/skopeo:latest \
+            copy docker://${aib_oci_image} oci-archive:///outputs/${aib_oci_archive}
+
+            sudo -E ./auto-image-builder.sh --verbose to-disk-image \
+            --build-container ${AIB_BUILD_CONTAINER_IMAGE} \
+            --oci-archive \
+            _build/outputs/${aib_oci_archive} \
+            _build/outputs/eclipse-autosd-bootc-${aib_target}-${{ matrix.platform }}.${aib_ext}
+
+            rm -f _build/outputs/${aib_oci_archive}
+          done
+      - name: Inspect and Cleanup outputs directory
+        run:
+          tree _build/outputs
+
+      - name: Store Disk Images
+        uses: actions/upload-artifact@v4
+        with:
+          name: outputs-${{ matrix.platform }}
+          path: _build/outputs/*
+  publish-disk-images:
+    needs: build-disk-image
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Install System Tools
+        run: |
+          sudo apt update -y
+          sudo apt install -y tree
+      - name: Prepare
+        run: |
+          mkdir -p _build/outputs
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: outputs-*
+          merge-multiple: true
+          path: _build/outputs
+      - name: Inspect Outputs
+        run: |
+          tree _build
+      - name: SCP artifacts to download.eclipse.org
+        uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345 # v1
+        with:
+          host: projects-storage.eclipse.org
+          username: ${{ secrets.SCP_USERNAME }}
+          key: ${{ secrets.SCP_KEY }}
+          passphrase: ${{ secrets.SCP_PASSPHRASE }}
+          source: "_build/outputs/*"
+          target: "/home/data/httpd/download.eclipse.org/autosd/disk-images/"
+          strip_components: 2


### PR DESCRIPTION
fixes #3 

# Changes

* Adds CI job to build and push disk images to https://download.eclipse.org/autosd
* Manual trigger only for now (will add a scheduled trigger in another PR)